### PR TITLE
Update openSUSE info

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This software is licensed under [GNU GPLv2 or later](https://www.gnu.org/license
 
 For [arch users](https://www.archlinux.org/) there is an AUR package [nm-tray-git](https://aur.archlinux.org/packages/nm-tray-git/) (thanks to [pmattern](https://github.com/pmattern)).
 
-For [openSUSE users](https://www.opensuse.org/) there is a [package](https://build.opensuse.org/package/show/X11:LXQt:git/nm-tray) in the [X11:LXQt:git](https://build.opensuse.org/project/show/X11:LXQt:git) devel project of OBS.
+nm-tray is in the official repository of [openSUSE](https://www.opensuse.org/) since Leap 15.0. There is a also a [git package](https://build.opensuse.org/package/show/X11:LXQt:git/nm-tray) in the [X11:LXQt:git](https://build.opensuse.org/project/show/X11:LXQt:git) devel project of OBS.
 
 ## Translations
 


### PR DESCRIPTION
Contained in official repos of Leap and Tumbleweed now.
Git package with latest version still also available.