### PR TITLE
Treat WireGuard connections as normal VPN connections

### DIFF
--- a/src/nmmodel.cpp
+++ b/src/nmmodel.cpp
@@ -1253,6 +1253,7 @@ QVariant NmModel::dataRole<NmModel::IconTypeRole>(const QModelIndex & index) con
                         }
                         break;
                     case NetworkManager::ConnectionSettings::Vpn:
+                    case NetworkManager::ConnectionSettings::WireGuard:
                         return icons::NETWORK_VPN;
                     default:
                         return NetworkManager::ActiveConnection::Activated == state ? icons::NETWORK_WIRED : icons::NETWORK_WIRED_DISCONNECTED;
@@ -1464,7 +1465,7 @@ void NmModel::activateConnection(QModelIndex const & index)
                 auto const & conn = d->mConnections[index.row()];
                 conn_uni = conn->path();
                 conn_name = conn->name();
-                if (NetworkManager::ConnectionSettings::Vpn == conn->settings()->connectionType())
+                if (NetworkManager::ConnectionSettings::Vpn == conn->settings()->connectionType() || NetworkManager::ConnectionSettings::WireGuard == conn->settings()->connectionType())
                 {
                     spec_object = dev_uni = QStringLiteral("/");
                     /*


### PR DESCRIPTION
WireGuard connections are pretty standard VPN connections, **but** they don't actually get tagged as such in NetworkManager.
This change just makes nm-tray treat them as normal VPN connections because they don't work otherwise.

Without this I was getting this message any time I tried to connect to one:

    nm-tray: can't find device 'CONNECTION_NAME' to activate connection 'CONNECTION_NAME' on