### PR TITLE
Support command arguments for connections editor

### DIFF
--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -348,7 +348,8 @@ bool Tray::eventFilter(QObject * object, QEvent * event)
 
 void Tray::onEditConnectionsTriggered()
 {
-    const QStringList connections_editor = QSettings{}.value(CONNECTIONS_EDITOR, QStringList{{"xterm", "-e", "nmtui-edit"}}).toStringList();
+    const QStringList connections_editor = QSettings{}.value(CONNECTIONS_EDITOR, QStringLiteral("xterm -e nmtui-edit")).toString().split(' ');
+
     if (connections_editor.empty() || connections_editor.front().isEmpty())
     {
         qCCritical(NM_TRAY) << "Can't start connection editor, because of misconfiguration. Value of"


### PR DESCRIPTION
Add support to command arguments for the connections editor.
Now possible to use for example the KDE connections editor with `systemsettings kcm_networkmanagement`.